### PR TITLE
handle actor ID change on future fetchSession calls

### DIFF
--- a/src/ReverseTree.test.ts
+++ b/src/ReverseTree.test.ts
@@ -9,6 +9,7 @@ test('reverse tree can insert items', () => {
 test('reverse tree skips unreceived dependencies', () => {
   const rt = new ReverseTree('me');
   rt.import(
+    'me',
     {
       id: 'doc',
       actors: ['me', 'you', 'foo'],

--- a/src/ReverseTree.ts
+++ b/src/ReverseTree.ts
@@ -51,8 +51,10 @@ export class ReverseTree {
     this.log = [];
   }
 
-  import(checkpoint: DocumentCheckpoint, listID: string) {
+  import(actor: string, checkpoint: DocumentCheckpoint, listID: string) {
     invariant(checkpoint);
+
+    this.actor = actor;
 
     this.log = [];
     this.nodes = {};

--- a/src/list.test.ts
+++ b/src/list.test.ts
@@ -32,6 +32,7 @@ test('list can import from checkpoint', () => {
   const { store } = ListInterpreter.newList('doc', 'list', 'actor');
   ListInterpreter.importFromRawCheckpoint(
     store,
+    'actor',
     checkpoint(
       'list',
       {

--- a/src/list.ts
+++ b/src/list.ts
@@ -41,6 +41,7 @@ function newList(
  */
 function importFromRawCheckpoint(
   store: ListStore,
+  actor: string,
   rawCheckpoint: DocumentCheckpoint,
   listID: string
 ) {
@@ -49,7 +50,7 @@ function importFromRawCheckpoint(
     return; // no import
   }
 
-  store.rt.import(rawCheckpoint, listID);
+  store.rt.import(actor, rawCheckpoint, listID);
   const list = rawCheckpoint.lists[listID];
   const ids = list.ids || [];
   for (let i = 0; i < ids.length; i++) {

--- a/src/list.ts
+++ b/src/list.ts
@@ -184,7 +184,7 @@ function runInsertAt<T extends any>(
   val: T
 ): string[] {
   if (index < 0) {
-    throw 'Negative indices unsupported';
+    throw new Error('Negative indices unsupported');
   }
   let afterID: string;
   if (index === 0) {

--- a/src/list.ts
+++ b/src/list.ts
@@ -187,7 +187,7 @@ function runInsertAt<T extends any>(
     throw 'Negative indices unsupported';
   }
   let afterID: string;
-  if (index == 0) {
+  if (index === 0) {
     afterID = 'root';
   } else {
     afterID = store.itemIDs[index - 1];


### PR DESCRIPTION
we'd get buggy behavior when the actor of a client changed (which was possible when refreshing sessions and each session has a random userID). this small change handles that case

in the future we could also choose to handle this by completely re-initializing clients when the actor ID changes (or prevent those from happening at all), but this was just a quick soluton to a bug I ran into locally