### PR TITLE
versionstamp fix

### DIFF
--- a/src/ReverseTree.test.ts
+++ b/src/ReverseTree.test.ts
@@ -9,7 +9,6 @@ test('reverse tree can insert items', () => {
 test('reverse tree skips unreceived dependencies', () => {
   const rt = new ReverseTree('me');
   rt.import(
-    'me',
     {
       id: 'doc',
       actors: ['me', 'you', 'foo'],

--- a/src/ReverseTree.ts
+++ b/src/ReverseTree.ts
@@ -50,10 +50,8 @@ export class ReverseTree {
     this.session = session;
   }
 
-  import(actor: string, checkpoint: DocumentCheckpoint, listID: string) {
+  import(checkpoint: DocumentCheckpoint, listID: string) {
     invariant(checkpoint);
-
-    this.session = actor;
 
     this.nodes = new Map();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 // Interpret Version Stamps
-export { vsReader } from './versionstamp';
+export { isOlderVS } from './versionstamp';
 export { MapInterpreter, MapMeta, MapStore } from './map';
 export { ListInterpreter, ListMeta, ListStore } from './list';
 export * from './types';

--- a/src/list.test.ts
+++ b/src/list.test.ts
@@ -21,7 +21,7 @@ function checkpoint(
 }
 
 test('new list create correct command', () => {
-  expect(ListInterpreter.newList('doc', 'list', 'actor').cmd).toEqual([
+  expect(ListInterpreter.newList('doc', 'list').cmd).toEqual([
     'mcreate',
     'doc',
     'list',
@@ -29,7 +29,7 @@ test('new list create correct command', () => {
 });
 
 test('list can import from checkpoint', () => {
-  const { store } = ListInterpreter.newList('doc', 'list', 'actor');
+  const { store } = ListInterpreter.newList('doc', 'list');
   ListInterpreter.importFromRawCheckpoint(
     store,
     'actor',
@@ -57,25 +57,27 @@ test('list can import from checkpoint', () => {
 });
 
 test('lists.push() creates multiple commands', () => {
-  const { store, meta } = ListInterpreter.newList('doc', 'list', 'act');
+  const { store, meta } = ListInterpreter.newList('doc', 'list');
+  const session = store.rt.session;
 
   const cmds = ListInterpreter.runPush<any>(store, meta, 1, 2, 3);
   expect(cmds).toEqual([
-    ['lins', 'doc', 'list', 'root', '0:act', '1'],
-    ['lins', 'doc', 'list', '0:act', '1:act', '2'],
-    ['lins', 'doc', 'list', '1:act', '2:act', '3'],
+    ['lins', 'doc', 'list', 'root', `0:${session}`, '1'],
+    ['lins', 'doc', 'list', `0:${session}`, `1:${session}`, '2'],
+    ['lins', 'doc', 'list', `1:${session}`, `2:${session}`, '3'],
   ]);
 });
 
 test("lists don't include extra quotes", () => {
-  const { store, meta } = ListInterpreter.newList('doc', 'list', 'coolactor');
+  const { store, meta } = ListInterpreter.newList('doc', 'list');
 
   ListInterpreter.runPush<any>(store, meta, '"1"', '2', 3, '');
   expect(ListInterpreter.toArray(store)).toEqual(['"1"', '2', 3, '']);
 });
 
 test('lists.map()', () => {
-  const { store, meta } = ListInterpreter.newList('doc', 'list', 'act');
+  const { store, meta } = ListInterpreter.newList('doc', 'list');
+  const session = store.rt.session;
 
   ListInterpreter.runPush<any>(store, meta, 1, 2, 3);
   expect(
@@ -83,59 +85,64 @@ test('lists.map()', () => {
       return [val, index, key];
     })
   ).toEqual([
-    [1, 0, '0:act'],
-    [2, 1, '1:act'],
-    [3, 2, '2:act'],
+    [1, 0, `0:${session}`],
+    [2, 1, `1:${session}`],
+    [3, 2, `2:${session}`],
   ]);
 });
 
 describe('list.applyCommand', () => {
   test('lins', () => {
-    const { store } = ListInterpreter.newList('doc', 'list', 'act');
+    const { store } = ListInterpreter.newList('doc', 'list');
 
-    ListInterpreter.applyCommand(store, [
-      'lins',
-      'doc',
-      'list',
-      'root',
-      '0:bob',
-      '2',
-    ]);
+    ListInterpreter.applyCommand(
+      store,
+      ['lins', 'doc', 'list', 'root', '0:bob', '2'],
+      btoa('1'),
+      false
+    );
 
     expect(ListInterpreter.get<any>(store, 0)).toEqual(2);
   });
 
   test('ldel', () => {
-    const { store, meta } = ListInterpreter.newList('doc', 'list', 'act');
+    const { store, meta } = ListInterpreter.newList('doc', 'list');
+    const session = store.rt.session;
 
     // ["dogs", "cats"]
     ListInterpreter.runPush(store, meta, 'dogs', 'cats');
 
     // delete "dogs"
-    ListInterpreter.applyCommand(store, ['ldel', 'doc', 'list', '0:act']);
+    ListInterpreter.applyCommand(
+      store,
+      ['ldel', 'doc', 'list', `0:${session}`],
+      btoa('1'),
+      false
+    );
 
     // Expect ["cats"]
     expect(ListInterpreter.get<any>(store, 0)).toEqual('cats');
   });
 
   test('lput', () => {
-    const { store, meta } = ListInterpreter.newList('doc', 'list', 'act');
+    const { store, meta } = ListInterpreter.newList('doc', 'list');
+    const session = store.rt.session;
 
     ListInterpreter.runPush(store, meta, 'dogs', 'cats');
-    ListInterpreter.applyCommand(store, [
-      'lput',
-      'doc',
-      'list',
-      '0:act',
-      'snakes',
-    ]);
+    ListInterpreter.applyCommand(
+      store,
+      ['lput', 'doc', 'list', `0:${session}`, 'snakes'],
+      btoa('1'),
+      false
+    );
 
     expect(ListInterpreter.get<any>(store, 0)).toEqual('snakes');
   });
 });
 
 test('list.insertAfter()', () => {
-  const { store, meta } = ListInterpreter.newList('doc', 'list', 'act');
+  const { store, meta } = ListInterpreter.newList('doc', 'list');
+  const session = store.rt.session;
 
   const insertAtCmd = ListInterpreter.runInsertAt(store, meta, 0, 'dogs');
   expect(insertAtCmd).toEqual([
@@ -143,7 +150,7 @@ test('list.insertAfter()', () => {
     'doc',
     'list',
     'root',
-    '0:act',
+    `0:${session}`,
     '"dogs"',
   ]);
 
@@ -152,10 +159,76 @@ test('list.insertAfter()', () => {
     'lins',
     'doc',
     'list',
-    '0:act',
-    '1:act',
+    `0:${session}`,
+    `1:${session}`,
     '"cats"',
   ]);
 
   expect(ListInterpreter.toArray(store)).toEqual(['dogs', 'cats']);
+});
+
+test('list local acks work correctly', () => {
+  const { store, meta } = ListInterpreter.newList('doc', 'list');
+
+  ListInterpreter.runPush(store, meta, 'v');
+  expect(ListInterpreter.toArray(store)).toEqual(['v']);
+
+  const id = store.rt.lastID();
+
+  // ack value ignored
+  ListInterpreter.applyCommand(
+    store,
+    ['lput', 'doc', 'list', id, '"v2"'],
+    btoa('1'),
+    true
+  );
+  expect(store.rt.nodes.get(id)!.value).toEqual('"v"');
+  expect(store.rt.nodes.get(id)!.versionstamp).toEqual(btoa('1'));
+
+  // old non-ack ignored
+  ListInterpreter.applyCommand(
+    store,
+    ['lput', 'doc', 'list', id, '"v2"'],
+    btoa('0'),
+    false
+  );
+  expect(store.rt.nodes.get(id)!.value).toEqual('"v"');
+  expect(store.rt.nodes.get(id)!.versionstamp).toEqual(btoa('1'));
+
+  // old ack ignored
+  ListInterpreter.applyCommand(
+    store,
+    ['lput', 'doc', 'list', id, '"v2"'],
+    btoa('0'),
+    true
+  );
+  expect(store.rt.nodes.get(id)!.value).toEqual('"v"');
+  expect(store.rt.nodes.get(id)!.versionstamp).toEqual(btoa('1'));
+
+  //  newer non-ack overwrites local
+  ListInterpreter.applyCommand(
+    store,
+    ['lput', 'doc', 'list', id, '"v2"'],
+    btoa('2'),
+    false
+  );
+  expect(store.rt.nodes.get(id)!.value).toEqual('"v2"');
+  expect(store.rt.nodes.get(id)!.versionstamp).toEqual(btoa('2'));
+});
+
+test('list handles out of order lput/lins', () => {
+  const { store } = ListInterpreter.newList('doc', 'list');
+  ListInterpreter.applyCommand(
+    store,
+    ['lput', 'doc', 'list', 'nodeid', '"putv"'],
+    btoa('2'),
+    false
+  );
+  ListInterpreter.applyCommand(
+    store,
+    ['lins', 'doc', 'list', 'root', 'nodeid', '"insertv"'],
+    btoa('1'),
+    false
+  );
+  expect(ListInterpreter.toArray(store)).toEqual(['putv']);
 });

--- a/src/list.ts
+++ b/src/list.ts
@@ -49,13 +49,13 @@ function newList(
 
 /**
  * Populates the store with the values given from a bootstrap'd
- * checkpoint, typically gotten from Room Service's API.
+ * checkpoint, typically from Room Service's API.
  * @param store
  * @param rawCheckpoint
  */
 function importFromRawCheckpoint(
   store: ListStore,
-  actor: string,
+  _actor: string,
   rawCheckpoint: DocumentCheckpoint,
   listID: string
 ) {
@@ -64,7 +64,7 @@ function importFromRawCheckpoint(
     return; // no import
   }
 
-  store.rt.import(actor, rawCheckpoint, listID);
+  store.rt.import(rawCheckpoint, listID);
   const list = rawCheckpoint.lists[listID];
   const ids = list.ids || [];
   for (let i = 0; i < ids.length; i++) {

--- a/src/map.test.ts
+++ b/src/map.test.ts
@@ -1,26 +1,30 @@
 import { MapInterpreter, MapStore, MapMeta } from './map';
 
 test('MapInterpreter can set()', () => {
-  const store: MapStore<any> = {};
+  const store: MapStore<any> = {
+    kv: new Map(),
+    tombstoneCleanup: [],
+  };
   const meta: MapMeta = {
     docID: 'doc',
     mapID: 'map',
   };
   const cmd = MapInterpreter.runSet(store, meta, 'dog', 'good');
-  expect(store['dog']).toEqual('good');
+  expect(store.kv.get('dog')?.value).toEqual('good');
   expect(cmd).toEqual(['mput', 'doc', 'map', 'dog', '"good"']);
 });
 
 test('MapInterpreter can delete()', () => {
   const store: MapStore<any> = {
-    snake: 'bad',
+    kv: new Map([['snake', { value: 'bad', local: false }]]),
+    tombstoneCleanup: [],
   };
   const meta: MapMeta = {
     docID: 'doc',
     mapID: 'map',
   };
   const cmd = MapInterpreter.runDelete(store, meta, 'snake');
-  expect(store['snake']).toBeFalsy();
+  expect(store.kv.get('snake')?.value).toBeUndefined();
   expect(cmd).toEqual(['mdel', 'doc', 'map', 'snake']);
 });
 
@@ -37,13 +41,179 @@ test('MapInterpreter can validate a bad command', () => {
 
 test('MapInterpreter can delete()', () => {
   const store: MapStore<any> = {
-    snake: 'bad',
+    kv: new Map([['snake', { value: 'bad', local: false }]]),
+    tombstoneCleanup: [],
   };
-  MapInterpreter.applyCommand(store, ['mdel', 'doc', 'map', 'snake']);
-  expect(store['snake']).toBeFalsy();
+  MapInterpreter.applyCommand(
+    store,
+    ['mdel', 'doc', 'map', 'snake'],
+    btoa('1'),
+    false
+  );
+  expect(store.kv.get('snake')?.value).toBeUndefined();
+});
+
+test('MapInterpreter delete() is cleaned up', () => {
+  const store: MapStore<any> = {
+    kv: new Map([['snake', { value: 'bad', local: false }]]),
+    tombstoneCleanup: [],
+  };
+  MapInterpreter.applyCommand(
+    store,
+    ['mdel', 'doc', 'map', 'snake'],
+    btoa('1'),
+    false
+  );
+
+  MapInterpreter.applyCommand(
+    store,
+    ['mput', 'doc', 'map', 'othersnake', 'good'],
+    btoa('2'),
+    false
+  );
+  expect(store.kv.has('snake')).toBeFalsy();
 });
 
 test('MapInterpreter can create a new map', () => {
   const cmd = MapInterpreter.newMap('doc', 'map').cmd;
   expect(cmd).toEqual(['mcreate', 'doc', 'map']);
+});
+
+test('MapInterpreter ignores old versionstamps', () => {
+  const { store } = MapInterpreter.newMap('doc', 'map');
+  MapInterpreter.applyCommand(
+    store,
+    ['mput', 'doc', 'map', 'k', 'v1'],
+    btoa('2'),
+    false
+  );
+  MapInterpreter.applyCommand(
+    store,
+    ['mput', 'doc', 'map', 'k', 'v2'],
+    btoa('1'),
+    false
+  );
+  expect(store.kv.get('k')!.value).toEqual('v1');
+});
+
+test('MapInterpreter local ack inserts work correctly', () => {
+  const { store, meta } = MapInterpreter.newMap('doc', 'map');
+  MapInterpreter.applyCommand(
+    store,
+    ['mput', 'doc', 'map', 'k', 'v1'],
+    btoa('2'),
+    false
+  );
+  //  local edits value
+  MapInterpreter.runSet(store, meta, 'k', 'vlocal');
+  expect(store.kv.get('k')!.value).toEqual('vlocal');
+
+  //  old vs ignored
+  MapInterpreter.applyCommand(
+    store,
+    ['mput', 'doc', 'map', 'k', 'v2'],
+    btoa('1'),
+    false
+  );
+  expect(store.kv.get('k')!.value).toEqual('vlocal');
+
+  //  old ack ignored
+  MapInterpreter.applyCommand(
+    store,
+    ['mput', 'doc', 'map', 'k', 'v2'],
+    btoa('1'),
+    true
+  );
+  expect(store.kv.get('k')!.value).toEqual('vlocal');
+
+  //  new ack value ignored
+  MapInterpreter.applyCommand(
+    store,
+    ['mput', 'doc', 'map', 'k', 'v2'],
+    btoa('3'),
+    true
+  );
+  expect(store.kv.get('k')!.value).toEqual('vlocal');
+  expect(store.kv.get('k')!.versionstamp).toEqual(btoa('3'));
+
+  //  new ack value still ignored
+  MapInterpreter.applyCommand(
+    store,
+    ['mput', 'doc', 'map', 'k', 'v2'],
+    btoa('4'),
+    true
+  );
+  expect(store.kv.get('k')!.value).toEqual('vlocal');
+  expect(store.kv.get('k')!.versionstamp).toEqual(btoa('4'));
+
+  //  newer non-ack overwrites local
+  MapInterpreter.applyCommand(
+    store,
+    ['mput', 'doc', 'map', 'k', 'v2'],
+    btoa('5'),
+    false
+  );
+  expect(store.kv.get('k')!.value).toEqual('v2');
+  expect(store.kv.get('k')!.versionstamp).toEqual(btoa('5'));
+});
+
+test('MapInterpreter local ack deletes work correctly', () => {
+  const { store, meta } = MapInterpreter.newMap('doc', 'map');
+  MapInterpreter.applyCommand(
+    store,
+    ['mput', 'doc', 'map', 'k', 'v1'],
+    btoa('2'),
+    false
+  );
+  //  local edits value
+  MapInterpreter.runSet(store, meta, 'k', 'vlocal');
+  expect(store.kv.get('k')!.value).toEqual('vlocal');
+
+  //  old vs ignored
+  MapInterpreter.applyCommand(
+    store,
+    ['mdel', 'doc', 'map', 'k'],
+    btoa('1'),
+    false
+  );
+  expect(store.kv.get('k')!.value).toEqual('vlocal');
+
+  //  old ack ignored
+  MapInterpreter.applyCommand(
+    store,
+    ['mdel', 'doc', 'map', 'k'],
+    btoa('1'),
+    true
+  );
+  expect(store.kv.get('k')!.value).toEqual('vlocal');
+
+  //  new ack value ignored
+  MapInterpreter.applyCommand(
+    store,
+    ['mdel', 'doc', 'map', 'k'],
+    btoa('3'),
+    true
+  );
+  expect(store.kv.get('k')!.value).toEqual('vlocal');
+  expect(store.kv.get('k')!.versionstamp).toEqual(btoa('3'));
+
+  //  new ack value still ignored
+  MapInterpreter.applyCommand(
+    store,
+    ['mdel', 'doc', 'map', 'k'],
+    btoa('4'),
+    true
+  );
+  expect(store.kv.get('k')!.value).toEqual('vlocal');
+  expect(store.kv.get('k')!.versionstamp).toEqual(btoa('4'));
+
+  //  newer non-ack overwrites local
+  MapInterpreter.applyCommand(
+    store,
+    ['mdel', 'doc', 'map', 'k'],
+    btoa('5'),
+    false
+  );
+  expect(store.kv.get('k')!.value).toBeUndefined();
+  expect(store.kv.get('k')!.versionstamp).toEqual(btoa('5'));
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,31 @@
+export const b64Decode = (function(): (s: string) => string {
+  if (isNodejs()) {
+    return s => Buffer.from(s, 'base64').toString('binary');
+  }
+  return window.atob;
+})();
+
+export const generateID: () => string = (() => {
+  if (isNodejs()) {
+    const crypto = require('crypto');
+    return () => {
+      return crypto.randomBytes(16).toString('base64');
+    };
+  } else {
+    return () => {
+      const arr = new Uint8Array(16);
+      crypto.getRandomValues(arr);
+      //    note this only works for short sequences because it is recursive
+      return btoa(String.fromCharCode.apply(null, Array.from(arr.values())));
+    };
+  }
+})();
+
+function isNodejs() {
+  return (
+    typeof 'process' !== 'undefined' &&
+    process &&
+    process.versions &&
+    process.versions.node
+  );
+}

--- a/src/versionstamp.test.ts
+++ b/src/versionstamp.test.ts
@@ -18,8 +18,20 @@ test('compareVS(older, newer) === true, 2', () => {
 
 const zero: string = 'AAAAAAAAAAAAAAo=';
 const one: string = 'AAAAAAAAAAAAAQo=';
+const zeroZero = 'AAAK';
+const zeroTwo = 'AAIK';
 
 test('0 < 1', () => {
   expect(vs.isOlderVS(zero, one)).toEqual(true);
   expect(vs.isOlderVS(one, zero)).toEqual(false);
+});
+
+test('00 < 1', () => {
+  expect(vs.isOlderVS(zeroZero, one)).toEqual(true);
+  expect(vs.isOlderVS(one, zeroZero)).toEqual(false);
+});
+
+test('02 > 1', () => {
+  expect(vs.isOlderVS(one, zeroTwo)).toEqual(true);
+  expect(vs.isOlderVS(zeroTwo, one)).toEqual(false);
 });

--- a/src/versionstamp.test.ts
+++ b/src/versionstamp.test.ts
@@ -1,19 +1,17 @@
-import { vsReader } from './versionstamp';
+import { isOlderVS } from './versionstamp';
 
-const reader = (s: string) => Buffer.from(s, 'base64').toString('binary');
-const vs = vsReader(reader);
 test('compareVS(older, newer) === true, 1', () => {
   const older = 'AAAAOO4jk5UAAA==';
   const newer = 'AAAAOTKy5nUAAA==';
-  expect(vs.isOlderVS(older, newer)).toBeTruthy();
-  expect(vs.isOlderVS(newer, older)).toBeFalsy();
+  expect(isOlderVS(older, newer)).toBeTruthy();
+  expect(isOlderVS(newer, older)).toBeFalsy();
 });
 
 test('compareVS(older, newer) === true, 2', () => {
   const older = 'AAAAOTKy5nUAAA==';
   const newer = 'AAAAOW+nMK8AAA==';
-  expect(vs.isOlderVS(older, newer)).toBeTruthy();
-  expect(vs.isOlderVS(newer, older)).toBeFalsy();
+  expect(isOlderVS(older, newer)).toBeTruthy();
+  expect(isOlderVS(newer, older)).toBeFalsy();
 });
 
 const zero: string = 'AAAAAAAAAAAAAAo=';
@@ -22,16 +20,16 @@ const zeroZero = 'AAAK';
 const zeroTwo = 'AAIK';
 
 test('0 < 1', () => {
-  expect(vs.isOlderVS(zero, one)).toEqual(true);
-  expect(vs.isOlderVS(one, zero)).toEqual(false);
+  expect(isOlderVS(zero, one)).toEqual(true);
+  expect(isOlderVS(one, zero)).toEqual(false);
 });
 
 test('00 < 1', () => {
-  expect(vs.isOlderVS(zeroZero, one)).toEqual(true);
-  expect(vs.isOlderVS(one, zeroZero)).toEqual(false);
+  expect(isOlderVS(zeroZero, one)).toEqual(true);
+  expect(isOlderVS(one, zeroZero)).toEqual(false);
 });
 
 test('02 > 1', () => {
-  expect(vs.isOlderVS(one, zeroTwo)).toEqual(true);
-  expect(vs.isOlderVS(zeroTwo, one)).toEqual(false);
+  expect(isOlderVS(one, zeroTwo)).toEqual(true);
+  expect(isOlderVS(zeroTwo, one)).toEqual(false);
 });

--- a/src/versionstamp.test.ts
+++ b/src/versionstamp.test.ts
@@ -1,6 +1,6 @@
 import { vsReader } from './versionstamp';
 
-const reader = (s: string) => Buffer.from(s).toString('base64');
+const reader = (s: string) => Buffer.from(s, 'base64').toString('binary');
 const vs = vsReader(reader);
 test('compareVS(older, newer) === true, 1', () => {
   const older = 'AAAAOO4jk5UAAA==';
@@ -14,4 +14,12 @@ test('compareVS(older, newer) === true, 2', () => {
   const newer = 'AAAAOW+nMK8AAA==';
   expect(vs.isOlderVS(older, newer)).toBeTruthy();
   expect(vs.isOlderVS(newer, older)).toBeFalsy();
+});
+
+const zero: string = 'AAAAAAAAAAAAAAo=';
+const one: string = 'AAAAAAAAAAAAAQo=';
+
+test('0 < 1', () => {
+  expect(vs.isOlderVS(zero, one)).toEqual(true);
+  expect(vs.isOlderVS(one, zero)).toEqual(false);
 });

--- a/src/versionstamp.ts
+++ b/src/versionstamp.ts
@@ -1,58 +1,17 @@
-/**
- * A tool to manipulate version stamps
- */
-export class VersionStamper {
-  // Node and Browsers do this differently.
-  // On Node, it's Buffer.from("mystring", "base64").toString("binary")
-  // On Browsers, it's window.atob("mystring")
-  private b64Decode: (data: string) => string;
-  constructor(b64Decode: (data: string) => string) {
-    this.b64Decode = b64Decode;
-  }
+import { b64Decode } from './util';
 
-  /**
-   * Given two version stamps, return true
-   * if the first parameter is older than
-   * the second one.
-   * @param older
-   * @param newer
-   */
-  isOlderVS(older: string, newer: string): boolean {
-    if (!older) return true;
-    if (!newer) return false;
+export function isOlderVS(older: string, newer: string): boolean {
+  if (!older) return true;
+  if (!newer) return false;
 
-    older = this.b64Decode(older);
-    newer = this.b64Decode(newer);
+  older = b64Decode(older);
+  newer = b64Decode(newer);
 
-    const maxLength = Math.max(older.length, newer.length);
-    older = leftPadZero(older, maxLength);
-    newer = leftPadZero(newer, maxLength);
+  const maxLength = Math.max(older.length, newer.length);
+  older = leftPadZero(older, maxLength);
+  newer = leftPadZero(newer, maxLength);
 
-    return older < newer;
-  }
-}
-
-/**
- * Lets you manipulate version stamps
- *
- * @example
- * ```
- * // In node
- * const vs = vsReader((s) => Buffer.from(s).toString("base64"));
- * ```
- *
- * @example
- * ```
- * // In the browser
- * const vs = vsReader(window.atob)
- * ```
- *
- * @param stringToB64 {Function} converts strings to base64
- */
-export function vsReader(
-  stringToB64: (data: string) => string
-): VersionStamper {
-  return new VersionStamper(stringToB64);
+  return older < newer;
 }
 
 function leftPadZero(input: string, desiredLen: number) {


### PR DESCRIPTION
previously approved:
- change recommended nodejs impl to decode
- use left-padded binary strings instead of ArrayBuffers for lexical comparison
  - handles versionstamps of different lengths

new changes:
incorporate `versionstamp` and `ack` into map and list updates. take into account whether current value is a local optimistic set