### PR TITLE
Removed platform checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "typescript": "^4.0.5"
   },
   "dependencies": {
+    "base64-js": "^1.5.1",
+    "nanoid": "^3.1.22",
     "tiny-invariant": "^1.1.0"
   }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,54 +1,7 @@
-export const b64Decode = (function(): (s: string) => string {
-  if (isWeb()) {
-    return window.atob;
-  }
-  if (isNodejs()) {
-    return s => Buffer.from(s, 'base64').toString('binary');
-  }
-  if (isReactNative()) {
-    const base64 = require('base64-js');
-    //    note this only works for short sequences because it is recursive
-    return (s: string) =>
-      String.fromCharCode.apply(
-        null,
-        Array.from((base64.toByteArray(s) as Uint8Array).values())
-      );
-  }
-  return window.atob;
-})();
+import { toByteArray } from 'base64-js';
+import { nanoid } from 'nanoid';
 
-export const generateID: () => string = (() => {
-  if (isNodejs()) {
-    const crypto = require('crypto');
-    return () => {
-      return crypto.randomBytes(16).toString('base64');
-    };
-  } else {
-    //  note React Native also takes this branch, but needs "react-native-get-random-values" npm package installed
-    return () => {
-      const arr = new Uint8Array(16);
-      crypto.getRandomValues(arr);
-      //    note this only works for short sequences because it is recursive
-      return btoa(String.fromCharCode.apply(null, Array.from(arr.values())));
-    };
-  }
-})();
+export const b64Decode = (str: string): string =>
+  String.fromCharCode.apply(null, Array.from(toByteArray(str).values()));
 
-function isWeb(): boolean {
-  return typeof document !== 'undefined';
-}
-
-function isNodejs(): boolean {
-  return (
-    typeof 'process' !== 'undefined' &&
-    !!process &&
-    !!process.versions &&
-    !!process.versions.node
-  );
-}
-
-function isReactNative(): boolean {
-  return (
-    typeof navigator !== 'undefined' && navigator.product === 'ReactNative'
-  );
-}
+export const generateID = (): string => nanoid(16);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1937,7 +1937,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base64-js@^1.0.2:
+base64-js@^1.0.2, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -5885,6 +5885,11 @@ nanoid@^3.1.16:
   version "3.1.16"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.16.tgz#b21f0a7d031196faf75314d7c65d36352beeef64"
   integrity sha512-+AK8MN0WHji40lj8AEuwLOvLSbWYApQpre/aFJZD71r43wVRLrOYS4FmJOPQYon1TqB462RzrrxlfA74XRES8w==
+
+nanoid@^3.1.22:
+  version "3.1.22"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.22.tgz#b35f8fb7d151990a8aebd5aa5015c03cf726f844"
+  integrity sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==
 
 nanomatch@^1.2.9:
   version "1.2.13"


### PR DESCRIPTION
**What does this PR does?**
This PR removes the necessity to check for the host platform in favor of isomorphic libraries.
It uses [nanoid](https://www.npmjs.com/package/nanoid) and [base64-js](https://www.npmjs.com/package/base64-js)

**Why?**
I personally had problems compiling `@roomservice/browser` with Snowpack because it was importing `crypto`. But now, it would work in the any weird platform because those libraries are written in plain JS and have zero dependencies.

**Sizes**
These are the new sizes (I'm not able to have the previous sizes):
```
dist/core.cjs.production.min.js
  Size limit: 10 KB
  Size:       3.94 KB with all dependencies, minified and gzipped
  
dist/core.esm.js
  Size limit: 10 KB
  Size:       3.76 KB with all dependencies, minified and gzipped
 ```
 
 Also, VSCode tells me that nanoid tells me what each dependency should add to the bundle size:
| Dependency | Raw Size | GZipped Size |
|:-:|:-:|:-:|
| `nanoid` | `551B` | `360B` |
| `base64-js` | `1.2KB` | `695B` |